### PR TITLE
[codex] Remove hard-coded TMDB key from test script

### DIFF
--- a/test.js
+++ b/test.js
@@ -1,10 +1,14 @@
 import { spawn } from 'child_process';
 
+if (!process.env.TMDB_API_KEY) {
+  console.error('TMDB_API_KEY is required. Export it before running this script.');
+  process.exit(1);
+}
+
 const proc = spawn('/opt/homebrew/opt/node@22/bin/node', ['dist/index.js'], {
   cwd: '/Users/ln/mcp-server-tmdb',
   env: {
-    ...process.env,
-    TMDB_API_KEY: '72e579cb54246d5c0dda13bc885cc2e6'
+    ...process.env
   }
 });
 


### PR DESCRIPTION
## Summary

- Removes the hard-coded TMDB API key from `test.js`.
- Makes the script require `TMDB_API_KEY` from the environment before launching the local server.

## Why

The previous test script contained a literal API key. Even if that key has been rotated, keeping it in the current tree is confusing and unsafe.

## Validation

- `node --check test.js`
- Scanned the branch for the old key literal and `TMDB_API_KEY: '` with no matches.